### PR TITLE
Make shielding free

### DIFF
--- a/GameData/KerbalismConfig/System/Resources.cfg
+++ b/GameData/KerbalismConfig/System/Resources.cfg
@@ -36,7 +36,7 @@ RESOURCE_DEFINITION
 {
   name = Shielding
   density = 1.35            // aluminum density = 2.7 g/cm³, so a 1 cm² x 50 cm column is 50 cm³ -> 135 g/cm² = 1.35 t/m²
-  unitCost = 1.0 //FIXME
+  unitCost = 0 // because a "realistic" cost isn't going to happen, and nonzero triggers a weird part-cost bug
   flowMode = ALL_VESSEL
   transfer = NONE
   isTweakable = true


### PR DESCRIPTION
To fix an odd bug: after saving and loading a .craft, the part
cost of every crew part gets reduced by its maximum shielding value
(i.e. the part's habitat surface * unitCost)